### PR TITLE
Fix clearHDRRestartNotice compilation error

### DIFF
--- a/YUViewLib/src/video/yuv/videoHandlerYUV.cpp
+++ b/YUViewLib/src/video/yuv/videoHandlerYUV.cpp
@@ -2985,7 +2985,7 @@ QLayout *videoHandlerYUV::createVideoHandlerControls(bool isSizeAndFormatFixed)
   }
   
   // Clear any restart notice from previous session (PRD Requirements 5.1 & 5.3)
-  clearHDRRestartNotice();
+  this->clearHDRRestartNotice();
 
   // Connect all the change signals from the controls to "connectWidgetSignals()"
   connect(ui.yuvFormatComboBox,


### PR DESCRIPTION
Add `this->` prefix to `clearHDRRestartNotice()` call to fix a compilation error.

---
<a href="https://cursor.com/background-agent?bcId=bc-a6d1b627-17c6-4243-ad30-473e3119d5b8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a6d1b627-17c6-4243-ad30-473e3119d5b8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

