### PR TITLE
Fix hdr rendering bugs and add restart

### DIFF
--- a/YUViewLib/src/ui/views/SplitViewWidget.cpp
+++ b/YUViewLib/src/ui/views/SplitViewWidget.cpp
@@ -182,35 +182,30 @@ void splitViewWidget::paintEvent(QPaintEvent *)
 
   // CRITICAL FIX: Check HDR overlay state properly with paint device validation
   if (m_hdrOverlayWidget && m_hdrOverlayWidget->isVisible()) {
-    // HDR OpenGL widget is handling all rendering
-    
-    // Check if the HDR widget is ready
+    // HDR OpenGL widget is handling the base video rendering.
+    // We still proceed with the rest of paintEvent so that logic like item->drawItem()
+    // runs to push frames to the HDR widget, but we avoid an early return.
+
     HDR_VideoWidget* hdrWidget = qobject_cast<HDR_VideoWidget*>(m_hdrOverlayWidget.data());
-    if (hdrWidget && hdrWidget->isReadyForRendering()) {
-      // HDR widget is ready and rendering, skip ALL QPainter operations
-      return;
-    } else {
+    if (!(hdrWidget && hdrWidget->isReadyForRendering())) {
       // HDR widget exists but not ready yet - show loading indicator safely
-      // CRITICAL FIX: Validate paint device thoroughly before QPainter creation
       if (isVisible() && width() > 0 && height() > 0 && !paintingActive()) {
         try {
           QPainter painter(this);
           if (painter.isActive() && painter.device()) {
             painter.fillRect(rect(), Qt::black);
-            
-            // Show loading indicator with better formatting
             painter.setPen(Qt::white);
             QFont font = painter.font();
             font.setPointSize(12);
             painter.setFont(font);
             painter.drawText(rect(), Qt::AlignCenter, "Initializing HDR display...");
-            painter.end();  // Explicitly end painter
+            painter.end();
           }
         } catch (...) {
           // Ignore any painting errors during HDR initialization
         }
       }
-      return;
+      // Do not return; allow drawItem() below to push frames once ready.
     }
   }
 

--- a/YUViewLib/src/video/HDR_VideoWidget.cpp
+++ b/YUViewLib/src/video/HDR_VideoWidget.cpp
@@ -11,6 +11,8 @@
 #include <QDateTime>    // For FPS timing
 #include <cmath>
 #include <vector>  // For 10-bit framebuffer grabbing
+#include <QPainter>
+#include "ui/views/SplitViewWidget.h"
 
 // Vertex data for full-screen quad (position + texture coordinates)
 // CRITICAL FIX: Use standard texture coordinates, flip image during upload instead
@@ -548,6 +550,25 @@ void HDR_VideoWidget::paintEvent(QPaintEvent* event)
         QOpenGLWidget::paintEvent(event);
         
         doneCurrent();
+
+        // Draw lightweight UI overlays (e.g., zoom indicator) on top of the HDR content
+        // Fetch zoom from parent split view
+        splitViewWidget* parentView = qobject_cast<splitViewWidget*>(parentWidget());
+        if (parentView) {
+            QPointF offset; double zoom = 1.0; double splitPoint = 0.5; int mode = 0;
+            parentView->getViewState(offset, zoom, splitPoint, mode);
+            if (zoom != 1.0) {
+                QPainter painter(this);
+                painter.setRenderHint(QPainter::TextAntialiasing);
+                QFont font("helvetica", 24);
+                painter.setFont(font);
+                painter.setPen(QColor(Qt::black));
+                QString zoomString = QString("x") + QString::number(zoom, 'g', (zoom < 0.5) ? 4 : 2);
+                QFontMetrics fm(font);
+                QPoint pos(10, fm.height());
+                painter.drawText(pos, zoomString);
+            }
+        }
         
     } catch (...) {
         qCritical() << "Exception in HDR_VideoWidget::paintEvent - OpenGL context issue";

--- a/YUViewLib/src/video/yuv/videoHandlerYUV.cpp
+++ b/YUViewLib/src/video/yuv/videoHandlerYUV.cpp
@@ -52,6 +52,7 @@
 #include <QThread>
 #include <QDebug>
 #include <QSettings>
+#include <QProcess>
 
 #include <video/HDRDetection.h>
 #include <video/HDRGlobalState.h>
@@ -3033,6 +3034,13 @@ QLayout *videoHandlerYUV::createVideoHandlerControls(bool isSizeAndFormatFixed)
           this,
           &videoHandlerYUV::slot10BitDisplayChanged);
   
+  // Initialize and connect "Restart now" button (hidden by default)
+  if (ui.buttonRestartNow)
+  {
+    ui.buttonRestartNow->setVisible(false);
+    connect(ui.buttonRestartNow, &QPushButton::clicked, this, &videoHandlerYUV::slotRestartNow);
+  }
+  
   // Connect distortion analysis buttons
   connect(ui.pushButtonFirstLevel,
           &QPushButton::clicked,
@@ -4882,6 +4890,10 @@ void videoHandlerYUV::showHDRRestartNotice(bool hdrEnabled)
   QString noticeText = baseText + " (重启后生效)";
   ui.checkBoxEnable10BitDisplay->setText(noticeText);
   
+  // Show the Restart button to let user apply immediately
+  if (ui.buttonRestartNow)
+    ui.buttonRestartNow->setVisible(true);
+  
   // Also show a non-blocking status message
   QWidget* parentWidget = ui.checkBoxEnable10BitDisplay->parentWidget();
   while (parentWidget && !parentWidget->inherits("QMainWindow")) {
@@ -4905,7 +4917,33 @@ void videoHandlerYUV::clearHDRRestartNotice()
   // This should be called after application restart to remove "(重启后生效)" text
   QString baseText = "Enable native 10-bit display";
   ui.checkBoxEnable10BitDisplay->setText(baseText);
+  
+  // Hide the Restart button on fresh startup (no pending change)
+  if (ui.buttonRestartNow)
+    ui.buttonRestartNow->setVisible(false);
   qDebug() << "videoHandlerYUV: Cleared HDR restart notice, restored normal checkbox text";
+}
+
+void videoHandlerYUV::slotRestartNow()
+{
+  // Ensure settings are flushed before restart
+  QSettings settings;
+  settings.sync();
+
+  // Restart the application in a platform-agnostic way
+  const QString program = QCoreApplication::applicationFilePath();
+  QStringList args = QCoreApplication::arguments();
+  if (!args.isEmpty())
+    args.removeFirst(); // Remove program name
+
+  bool started = QProcess::startDetached(program, args, QDir::currentPath());
+  if (!started)
+  {
+    QMessageBox::warning(nullptr, "Restart failed", "YUView could not be restarted automatically. Please restart it manually.");
+    return;
+  }
+
+  QApplication::quit();
 }
 
 } // namespace video::yuv

--- a/YUViewLib/src/video/yuv/videoHandlerYUV.h
+++ b/YUViewLib/src/video/yuv/videoHandlerYUV.h
@@ -306,6 +306,9 @@ private slots:
   void on_revertButton_L1_clicked();
   void on_revertButton_L2_clicked();
   
+  // Restart the application immediately to apply HDR setting
+  void slotRestartNow();
+  
   // Original file helper functions (still needed for distortion analysis)
   QString getCurrentFilePath() const;
   bool isCurrentFileOri(const QString &filePath) const;

--- a/YUViewLib/ui/videoHandlerYUV.ui
+++ b/YUViewLib/ui/videoHandlerYUV.ui
@@ -207,20 +207,37 @@
         </widget>
        </item>
        <item row="4" column="1">
-        <widget class="QCheckBox" name="checkBoxEnable10BitDisplay">
-         <property name="enabled">
-          <bool>true</bool>
-         </property>
-         <property name="toolTip">
-          <string>Enable native 10-bit display support for 10-bit YUV sources. This preserves 10-bit precision during YUV to RGB conversion.</string>
-         </property>
-         <property name="text">
-          <string>Enable native 10-bit display</string>
-         </property>
-         <property name="checked">
-          <bool>false</bool>
-         </property>
-        </widget>
+        <layout class="QVBoxLayout" name="hdrDisplayLayout">
+         <item>
+          <widget class="QCheckBox" name="checkBoxEnable10BitDisplay">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
+           <property name="toolTip">
+            <string>Enable native 10-bit display support for 10-bit YUV sources. This preserves 10-bit precision during YUV to RGB conversion.</string>
+           </property>
+           <property name="text">
+            <string>Enable native 10-bit display</string>
+           </property>
+           <property name="checked">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="buttonRestartNow">
+           <property name="text">
+            <string>Restart now</string>
+           </property>
+           <property name="toolTip">
+            <string>Restart YUView now to apply HDR display changes</string>
+           </property>
+           <property name="visible">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </item>
        <item row="5" column="0">
         <widget class="QLabel" name="labelDistortionAnalysis">


### PR DESCRIPTION
Add a "Restart now" button for immediate HDR setting application and enable full UI functionality (playback, zoom, analysis) in HDR rendering mode.

Previously, enabling native 10-bit display required a manual restart, and once active, the HDR rendering path bypassed most UI drawing and interaction logic in `SplitViewWidget`, leading to disabled playback controls, frame stepping, distortion analysis, and zoom indicators. This PR resolves these limitations by ensuring the `SplitViewWidget` continues to process drawing commands for its items, which in turn push frames to the `HDR_VideoWidget`, and by adding the zoom indicator directly within the HDR rendering context.

---
<a href="https://cursor.com/background-agent?bcId=bc-35aee58a-b660-4223-815a-f6ea7bb605c6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-35aee58a-b660-4223-815a-f6ea7bb605c6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

