### PR TITLE
Investigate pq st2084 curve shader rendering

### DIFF
--- a/YUViewLib/src/video/HDR_VideoWidget.cpp
+++ b/YUViewLib/src/video/HDR_VideoWidget.cpp
@@ -39,6 +39,7 @@ HDR_VideoWidget::HDR_VideoWidget(QWidget* parent)
     , m_hdrGamma(1.0f)
     , m_displayMaxLuminance(1000.0f)  // Default HDR display capability
     , m_sourceMaxLuminance(100.0f)    // Default SDR content assumption
+    , m_applyColorSpaceConversion(false) // Default: don't convert color space
     , m_shaderProgram(nullptr)
     , m_videoTexture(nullptr)
     , m_vertexBuffer(nullptr)
@@ -52,6 +53,7 @@ HDR_VideoWidget::HDR_VideoWidget(QWidget* parent)
     , m_sourceMaxLuminanceLocation(-1)
     , m_textureMatrixLocation(-1)
     , m_projectionMatrixLocation(-1)
+    , m_applyColorSpaceConversionLocation(-1)
     , m_frameUpdated(false)
     , m_fpsTimer(nullptr)
     , m_frameCount(0)
@@ -280,6 +282,26 @@ void HDR_VideoWidget::setSourceMaxLuminance(float maxLuminance)
         }
         
         // Source max luminance updated
+    }
+}
+
+void HDR_VideoWidget::setApplyColorSpaceConversion(bool apply)
+{
+    if (m_applyColorSpaceConversion != apply) {
+        m_applyColorSpaceConversion = apply;
+        
+        if (m_initialized) {
+            QMetaObject::invokeMethod(this, [this]() {
+                if (context() && context()->isValid()) {
+                    makeCurrent();
+                    updateShaderUniforms();
+                    doneCurrent();
+                    update();
+                }
+            }, Qt::QueuedConnection);
+        }
+        
+        qDebug() << "HDR_VideoWidget: Color space conversion" << (apply ? "enabled" : "disabled");
     }
 }
 
@@ -660,6 +682,7 @@ uniform float hdrExposure;         // HDR exposure adjustment
 uniform float hdrGamma;            // Gamma correction
 uniform float displayMaxLuminance; // Display peak luminance in nits (from HDRDetection)
 uniform float sourceMaxLuminance;  // Source content peak luminance in nits
+uniform bool applyColorSpaceConversion; // Whether to convert Rec.709 to Rec.2020
 
 // ST.2084 PQ constants for HDR10
 const float m1 = 2610.0 / 4096.0 / 4.0;
@@ -714,13 +737,19 @@ void main()
     vec4 color = texture(videoTexture, TexCoord);
     
     if (renderMode == 1) {
-        // BT.2020 + PQ: Assume incoming texture is Rec.709 OETF-encoded SDR
-        // 1) Linearize Rec.709, 2) Convert primaries to Rec.2020 in linear, 3) Map to absolute nits
-        // 4) Normalize to 10000 nits and apply ST.2084 OETF. No extra gamma on PQ path.
-        vec3 rgb709 = clamp(color.rgb, 0.0, 1.0);
-        vec3 rgb709_linear = rec709ToLinear(rgb709);
-        vec3 rgb2020_linear = from709to2020 * rgb709_linear;
-        vec3 pqEncoded = applyPQ(rgb2020_linear);
+        // BT.2020 + PQ: Apply PQ encoding with optional color space conversion
+        // 1) Linearize assuming Rec.709/sRGB gamma
+        // 2) Optionally convert color primaries to Rec.2020
+        // 3) Map to absolute nits and apply ST.2084 OETF
+        vec3 rgb = clamp(color.rgb, 0.0, 1.0);
+        vec3 rgb_linear = rec709ToLinear(rgb);
+        
+        // Apply color space conversion only if requested
+        if (applyColorSpaceConversion) {
+            rgb_linear = from709to2020 * rgb_linear;
+        }
+        
+        vec3 pqEncoded = applyPQ(rgb_linear);
         FragColor = vec4(pqEncoded, color.a);
         
     } else if (renderMode == 2) {
@@ -764,6 +793,7 @@ void main()
     m_sourceMaxLuminanceLocation = m_shaderProgram->uniformLocation("sourceMaxLuminance");
     m_textureMatrixLocation = m_shaderProgram->uniformLocation("textureMatrix");
     m_projectionMatrixLocation = m_shaderProgram->uniformLocation("projectionMatrix");
+    m_applyColorSpaceConversionLocation = m_shaderProgram->uniformLocation("applyColorSpaceConversion");
     
     qDebug() << "HDR shaders compiled and linked successfully";
     return true;
@@ -1119,6 +1149,7 @@ void HDR_VideoWidget::updateShaderUniforms()
     m_shaderProgram->setUniformValue(m_sourceMaxLuminanceLocation, m_sourceMaxLuminance);
     m_shaderProgram->setUniformValue(m_textureMatrixLocation, m_textureMatrix);
     m_shaderProgram->setUniformValue(m_projectionMatrixLocation, m_projectionMatrix);
+    m_shaderProgram->setUniformValue(m_applyColorSpaceConversionLocation, m_applyColorSpaceConversion);
 }
 
 void HDR_VideoWidget::updateProjectionMatrix()

--- a/YUViewLib/src/video/HDR_VideoWidget.h
+++ b/YUViewLib/src/video/HDR_VideoWidget.h
@@ -54,6 +54,10 @@ public:
     void setSourceMaxLuminance(float maxLuminance);
     float getSourceMaxLuminance() const { return m_sourceMaxLuminance; }
     
+    // Color space conversion control
+    void setApplyColorSpaceConversion(bool apply);
+    bool getApplyColorSpaceConversion() const { return m_applyColorSpaceConversion; }
+    
     // Status queries
     bool isHDRCapable() const { return m_hdrCapable; }
     bool isInitialized() const { return m_initialized; }
@@ -169,6 +173,7 @@ private:
     float m_hdrGamma;            // Gamma correction (0.1 to 5.0)
     float m_displayMaxLuminance; // Display peak luminance in nits (from HDRDetection)
     float m_sourceMaxLuminance;  // Source content peak luminance in nits (from video metadata)
+    bool m_applyColorSpaceConversion; // Whether to convert from Rec.709 to Rec.2020
     
     // OpenGL objects
     QOpenGLShaderProgram* m_shaderProgram;
@@ -186,6 +191,7 @@ private:
     int m_sourceMaxLuminanceLocation;
     int m_textureMatrixLocation;
     int m_projectionMatrixLocation;
+    int m_applyColorSpaceConversionLocation;
     
     // Transformation matrices
     QMatrix4x4 m_textureMatrix;


### PR DESCRIPTION
Remove the default Rec.709 to Rec.2020 color space conversion and add an optional control to prevent desaturated HDR output.

The previous implementation unconditionally converted Rec.709 primaries to Rec.2020 before PQ encoding. This often resulted in a "grayish" or "washed out" appearance for source content that was not strictly Rec.709 or when the display expected Rec.709 primaries within a PQ signal. This change makes the conversion optional, defaulting to off, to maintain source color saturation unless explicitly required.

---
<a href="https://cursor.com/background-agent?bcId=bc-9741daa8-8a79-46e5-b938-25b078064e46">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9741daa8-8a79-46e5-b938-25b078064e46">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

